### PR TITLE
Update flush interval of fluentd

### DIFF
--- a/production/efk-client/fluentd/aggregator/aggregator-client-config.yaml
+++ b/production/efk-client/fluentd/aggregator/aggregator-client-config.yaml
@@ -40,7 +40,7 @@ data:
           flush_mode interval
           retry_type exponential_backoff
           flush_thread_count 3
-          flush_interval 4s
+          flush_interval 5s
           retry_forever
           retry_max_interval 30
           chunk_limit_size 2M

--- a/production/efk-client/fluentd/aggregator/aggregator-client-config.yaml
+++ b/production/efk-client/fluentd/aggregator/aggregator-client-config.yaml
@@ -40,11 +40,11 @@ data:
           flush_mode interval
           retry_type exponential_backoff
           flush_thread_count 3
-          flush_interval 2s
+          flush_interval 4s
           retry_forever
           retry_max_interval 30
           chunk_limit_size 2M
-          queue_limit_length 8
+          queue_limit_length 32
           overflow_action block
         </buffer>
       </store>

--- a/production/efk-client/fluentd/forwarder/forwarder-client-config.yaml
+++ b/production/efk-client/fluentd/forwarder/forwarder-client-config.yaml
@@ -86,7 +86,7 @@ data:
         heartbeat_type tcp
         buffer_chunk_limit 2M
         buffer_queue_limit 32
-        flush_interval 4s
+        flush_interval 5s
         max_retry_wait 15
         disable_retry_limit
         num_threads 8

--- a/production/efk-client/fluentd/forwarder/forwarder-client-config.yaml
+++ b/production/efk-client/fluentd/forwarder/forwarder-client-config.yaml
@@ -86,7 +86,7 @@ data:
         heartbeat_type tcp
         buffer_chunk_limit 2M
         buffer_queue_limit 32
-        flush_interval 2s
+        flush_interval 4s
         max_retry_wait 15
         disable_retry_limit
         num_threads 8

--- a/production/efk-server/ingress/e2e-logs-ing.yaml
+++ b/production/efk-server/ingress/e2e-logs-ing.yaml
@@ -9,11 +9,11 @@ metadata:
    kubernetes.io/tls-acme: "true"
    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-   nginx.ingress.kubernetes.io/proxy-body-size: 10M
+   nginx.ingress.kubernetes.io/proxy-body-size: 15M
 spec:
   tls:
   - hosts:
-    - e2elogs.test.openebs.io
+    - e2elogs.openebs.ci
     secretName: e2e-logging-ingress
   rules:
   - host: e2elogs.openebs.ci


### PR DESCRIPTION
This PR:
- Updates the fluentd flush interval 
- Increase the queue limit length of aggregator to 32
Signed-off-by: Shivesh Abhishek <shivesh.abhishek@mayadata.io>