### PR TITLE
update elasticsearch url and change index-pattern-id

### DIFF
--- a/workload/efk-client/fluentd/aggregator/aggregator-client-config.yaml
+++ b/workload/efk-client/fluentd/aggregator/aggregator-client-config.yaml
@@ -33,7 +33,7 @@ data:
         scheme https
         ssl_version TLSv1_2
         include_tag_key true
-        hosts https://e2elogs.openebs.ci:443/es/
+        hosts https://es.openebs100.io/
         <buffer>
           @type file
           path /var/log/fluentd-buffers/kubernetes.system.buffer.aggregator

--- a/workload/efk-server/README.md
+++ b/workload/efk-server/README.md
@@ -23,7 +23,7 @@ Now, since we have the indices  as *cluster-logs-DATE* , we need to make a curl 
 So, the curl request goes like this:
 
 ```
-curl -XPOST https://e2elogs.openebs.ci/api/saved_objects/index-pattern/8d3d6950-ea9c-11e8-8cff-a161f7929609 -d '
+curl -XPOST https://e2elogs.openebs.ci/api/saved_objects/index-pattern/cluster-logs -d '
    {
      "attributes": {
        "title": "cluster-logs-*",


### PR DESCRIPTION
This PR:
- updates elasticsearch url from `https://e2elogs.openebs.ci/es/` to `https://es.openebs100.io/` 
- changes the index-pattern-id to a generic name

Signed-off-by: Shivesh Abhishek <shivesh.abhishek@mayadata.io>