### PR TITLE
add config to reconnect to elasticsearch when fails

### DIFF
--- a/workload/efk-client/fluentd/aggregator/aggregator-client-config.yaml
+++ b/workload/efk-client/fluentd/aggregator/aggregator-client-config.yaml
@@ -28,6 +28,9 @@ data:
         @type elasticsearch
         logstash_format true
         include_timestamp true
+        unrecoverable_error_types ["out_of_memory_error"]
+        # this indicates that the plugin should reset connection on any error
+        reconnect_on_error true
         logstash_prefix cluster-logs
         # Important (required to connect with elasticsearch with https request)
         scheme https


### PR DESCRIPTION
This PR:
- adds `reconnect_on_error` to fix retrying connection to elasticsearch.
- adds `unrecoverable_error_types ["out_of_memory_error"]` to fix `es_rejected_execution_exception` which is caused by exceeding Elasticsearch's thread pool capacity

Signed-off-by: Shivesh Abhishek <shivesh.abhishek@mayadata.io>