### PR TITLE
Add security context to forwarder daemonset

### DIFF
--- a/workload/efk-client/fluentd/forwarder/forwarder-client-ds.yaml
+++ b/workload/efk-client/fluentd/forwarder/forwarder-client-ds.yaml
@@ -69,6 +69,8 @@ spec:
       containers:
       - name: fluentd-forwarder
         image: k8s.gcr.io/fluentd-elasticsearch:v2.2.0
+        securityContext:
+          privileged: true
         env:
         - name: FLUENTD_CONFIG
           value: fluentd-forwarder.conf


### PR DESCRIPTION
- Fluentd needs the root permission to write inside /var/log directory.
- Fluentd creates pos file inside /var/log.

Signed-off-by: Sumit Lalwani <sumit.lalwani97@gmail.com>